### PR TITLE
Add service object

### DIFF
--- a/REF.md
+++ b/REF.md
@@ -22,6 +22,9 @@
 - [ActionView::Helpers::FormTagHelper](https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html)
 - [ActiveModel::SecurePassword::ClassMethods](https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html)
 - [ruby on rails - How do I make a before_action to run on all controllers and actions except one? - Stack Overflow](https://stackoverflow.com/questions/36302866/how-do-i-make-a-before-action-to-run-on-all-controllers-and-actions-except-one)
+- [Ruby on Rails チュートリアル：8.2.2 現在のユーザー](https://railstutorial.jp/chapters/basic_login?version=5.1#sec-current_user)
+- [A simple explanation of Service Objects for Ruby on Rails](https://medium.freecodecamp.org/service-objects-explained-simply-for-ruby-on-rails-5-a8cc42a5441f)
+- [Railsで重要なパターンpart 1: Service Object（翻訳）](https://techracho.bpsinc.jp/hachi8833/2017_10_16/46482)
 
 ## Docker
 

--- a/web/app/controllers/inspections_controller.rb
+++ b/web/app/controllers/inspections_controller.rb
@@ -22,7 +22,7 @@ class InspectionsController < ApplicationController
 
     flash[:success] = '検査項目を追加しました。'
     CreateLogService.call(
-      employee_id: current_employee_id,
+      employee_id: current_employee.id,
       order_id:    @order.id,
       content:     '追加 : __に検査を追加しました。'
     )
@@ -40,7 +40,7 @@ class InspectionsController < ApplicationController
 
     flash[:success] = '更新しました。'
     CreateLogService.call(
-      employee_id: current_employee_id,
+      employee_id: current_employee.id,
       order_id:    @inspection.order.id,
       content:     '変更 : __の検査を変更しました。'
     )

--- a/web/app/controllers/inspections_controller.rb
+++ b/web/app/controllers/inspections_controller.rb
@@ -12,19 +12,13 @@ class InspectionsController < ApplicationController
   def new; end
 
   def create
-    p = new_params
-    if p[:inspections].include?('')
+    if create_params[:inspections].include?('')
       flash.now[:warning] = '検査項目は必ず指定してください。'
       render :new, status: :bad_request
       return
     end
 
-    # inspections is array of inspection_detail's id(string)
-    p[:inspections].each do |id|
-      @order.inspections.create!(
-        inspection_detail: InspectionDetail.find_by(id: id)
-      )
-    end
+    CreateInspectionService.call(order: @order, inspections: create_params[:inspections])
 
     flash[:success] = '検査項目を追加しました。'
     CreateLogService.call(
@@ -68,7 +62,7 @@ class InspectionsController < ApplicationController
     @order = Order.find_by(id: params[:order_id])
   end
 
-  def new_params
+  def create_params
     params.require(:order).permit(inspections: [])
   end
 

--- a/web/app/controllers/inspections_controller.rb
+++ b/web/app/controllers/inspections_controller.rb
@@ -27,7 +27,11 @@ class InspectionsController < ApplicationController
     end
 
     flash[:success] = '検査項目を追加しました。'
-    create_log_with_add_inspections
+    CreateLogService.call(
+      employee_id: current_employee_id,
+      order_id:    @order.id,
+      content:     '追加 : __に検査を追加しました。'
+    )
     redirect_to order_inspections_path(@order)
   end
 
@@ -41,7 +45,11 @@ class InspectionsController < ApplicationController
     @inspection.update!(update_params)
 
     flash[:success] = '更新しました。'
-    create_log_with_update_inspection
+    CreateLogService.call(
+      employee_id: current_employee_id,
+      order_id:    @inspection.order.id,
+      content:     '変更 : __の検査を変更しました。'
+    )
     redirect_to order_inspections_url(@inspection.order)
   end
 
@@ -66,15 +74,5 @@ class InspectionsController < ApplicationController
 
   def update_params
     params.require(:inspection).permit(:status_id, :urgent, :canceled)
-  end
-
-  def create_log_with_add_inspections
-    e = Employee.find(current_employee)
-    e.logs.create!(order_id: @order.id, content: '追加 : __に検査を追加しました。')
-  end
-
-  def create_log_with_update_inspection
-    e = Employee.find(current_employee)
-    e.logs.create!(order_id: @inspection.order.id, content: '変更 : __の検査を変更しました。')
   end
 end

--- a/web/app/controllers/orders_controller.rb
+++ b/web/app/controllers/orders_controller.rb
@@ -22,7 +22,7 @@ class OrdersController < ApplicationController
 
     flash[:success] = "オーダー##{@order.id}を作成しました。"
     CreateLogService.call(
-      employee_id: current_employee_id,
+      employee_id: current_employee.id,
       order_id:    @order.id,
       content:     "作成 : 患者#{@order.patient.name}に__を作成しました。"
     )
@@ -39,7 +39,7 @@ class OrdersController < ApplicationController
 
     flash[:success] = '更新しました。'
     CreateLogService.call(
-      employee_id: current_employee_id,
+      employee_id: current_employee.id,
       order_id:    @order.id,
       content:     "変更 : __を#{@order.canceled? ? 'キャンセル' : '再予約'}しました。"
     )

--- a/web/app/controllers/orders_controller.rb
+++ b/web/app/controllers/orders_controller.rb
@@ -28,7 +28,11 @@ class OrdersController < ApplicationController
     end
 
     flash[:success] = "オーダー##{@order.id}を作成しました。"
-    create_log_with_new_order
+    CreateLogService.call(
+      employee_id: current_employee_id,
+      order_id:    @order.id,
+      content:     "作成 : 患者#{@order.patient.name}に__を作成しました。"
+    )
     redirect_to order_inspections_path(@order)
   end
 
@@ -41,7 +45,11 @@ class OrdersController < ApplicationController
     @order.update!(update_params)
 
     flash[:success] = '更新しました。'
-    create_log_with_update_order
+    CreateLogService.call(
+      employee_id: current_employee_id,
+      order_id:    @order.id,
+      content:     "変更 : __を#{@order.canceled? ? 'キャンセル' : '再予約'}しました。"
+    )
     redirect_to patient_orders_path(@order.patient)
   end
 
@@ -69,15 +77,5 @@ class OrdersController < ApplicationController
 
   def update_params
     params.require(:order).permit(:canceled)
-  end
-
-  def create_log_with_new_order
-    e = Employee.find(current_employee)
-    e.logs.create!(order_id: @order.id, content: "作成 : 患者#{@order.patient.name}に__を作成しました。")
-  end
-
-  def create_log_with_update_order
-    e = Employee.find(current_employee)
-    e.logs.create!(order_id: @order.id, content: "変更 : __をキャンセルしました。")
   end
 end

--- a/web/app/controllers/patients_controller.rb
+++ b/web/app/controllers/patients_controller.rb
@@ -2,6 +2,7 @@
 
 class PatientsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :no_patient
+
   def index
     @patients = Patient.all
   end

--- a/web/app/helpers/application_helper.rb
+++ b/web/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   end
 
   # returns logged in employee id
-  def current_employee
+  def current_employee_id
     session[:current_employee_id]
   end
 

--- a/web/app/helpers/application_helper.rb
+++ b/web/app/helpers/application_helper.rb
@@ -8,9 +8,9 @@ module ApplicationHelper
     render 'layouts/breadcrumb', links: [{ text: 'Home', href: root_path }] + links
   end
 
-  # returns logged in employee id
-  def current_employee_id
-    session[:current_employee_id]
+  # returns logged in employee
+  def current_employee
+    @current_employee ||= Employee.find_by(id: session[:current_employee_id])
   end
 
   # this is almost same as `current_employee` but this returns Boolean

--- a/web/app/service/create_inspection_service.rb
+++ b/web/app/service/create_inspection_service.rb
@@ -1,0 +1,14 @@
+class CreateInspectionService
+  include ServiceHelper
+
+  def initialize(order:, inspections:)
+    @order = order
+    @inspections = inspections
+  end
+
+  def call
+    @inspections.each do |id|
+      @order.inspections.create!(inspection_detail: InspectionDetail.find(id))
+    end
+  end
+end

--- a/web/app/service/create_log_service.rb
+++ b/web/app/service/create_log_service.rb
@@ -1,0 +1,21 @@
+class CreateLogService
+  include ServiceHelper
+
+  def initialize(employee_id:, order_id:, content:)
+    @employee_id = employee_id
+    @order_id    = order_id
+    @content     = content
+  end
+
+  def call
+    employee.logs.create!(order_id: order_id, content: content)
+  end
+
+  private
+
+  attr_reader :employee_id, :order_id, :content
+
+  def employee
+    @employee ||= Employee.find(employee_id)
+  end
+end

--- a/web/app/service/service_helper.rb
+++ b/web/app/service/service_helper.rb
@@ -1,0 +1,9 @@
+module ServiceHelper
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def call(*args)
+      new(*args).call
+    end
+  end
+end

--- a/web/app/views/layouts/_header.html.slim
+++ b/web/app/views/layouts/_header.html.slim
@@ -13,6 +13,7 @@ nav.navbar.has-shadow(role='navigation' aria-label="main navigation")
       = link_to 'Patients', patients_path, class: 'navbar-item is-hidden-tablet'
       = link_to 'Create order', new_order_path, class: 'navbar-item is-hidden-tablet'
       - if logged_in?
+        = link_to current_employee.fullname, employee_path(current_employee), class: 'navbar-item'
         = link_to 'Log out', logout_path, class: 'navbar-item', method: :delete
       - else
         = link_to 'Sign up', '#', class: 'navbar-item is-active'


### PR DESCRIPTION
Fixes #23.

- オーダーのキャンセル/再予約(キャンセルを取り消すこと)時に、状態に合わせたメッセージを表示させるようにしました。
- `e.logs.create!(...)`という似た冗長な処理を、`CreateLogService`として外部に移譲し簡潔にしました。
- 同様にオーダーに対して新しく検査を追加する処理も`CreateInspectionService`として切り出し、Controllerの記述をなるべく簡易にしました。
- `current_employee`がID情報しか返してなかった(以前はそれ以上の情報は必要なかった)ため、扱いやすいようEmployeeのインスタンスを返すように修正しました。
  - これに伴って、ログイン中は従業員氏名が右上に表示されます。