### PR TITLE
Use plain app-id instead of ENV

### DIFF
--- a/nginx/ordering-dev.conf
+++ b/nginx/ordering-dev.conf
@@ -1,9 +1,34 @@
 server {
   listen 80;
+  listen [::]:80;
+  server_name ordering-dev.tk;
+
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
   server_name ordering-dev.tk;
 
   root /www/ordering-dev/current/public;
 
   passenger_enabled on;
   passenger_ruby /home/deploy/.rbenv/versions/2.5.1/bin/ruby;
+
+  ssl_certificate "/etc/letsencrypt/live/ordering-dev.tk/cert.pem";
+  ssl_certificate_key "/etc/letsencrypt/live/ordering-dev.tk/privkey.pem";
+  ssl_session_cache shared:SSL:1m;
+  ssl_session_timeout 10m;
+  ssl_ciphers HIGH:!aNULL:!MD5;
+  ssl_prefer_server_ciphers on;
+
+  location ^~ /assets/ {
+    access_log off;
+    gzip_static on;
+    add_header Cache-Control public;
+    add_header ETag "";
+    add_header Access-Control-Allow-Origin *;
+    add_header Access-Control-Request-Method *;
+  }
 }

--- a/web/app/assets/javascripts/application.js
+++ b/web/app/assets/javascripts/application.js
@@ -20,32 +20,10 @@
 var OneSignal = window.OneSignal || [];
 OneSignal.push(function() {
   OneSignal.init({
-    appId: '<%= ENV['ONESIGNAL_APP_ID'] %>',
+    appId: '4da1e994-415c-4251-a406-9724d22aa247',
     autoRegister: true,
-    allowLocalhostAsSecureOrigin: true,
     notifyButton: {
       enable: true
     },
   });
-
-  OneSignal.on('subscriptionChange', function (isSubscribed) {
-    if (isSubscribed) {
-      OneSignal.getUserId(function(userId) {
-        var user_params = { onesignal_id: userId };
-
-        // these flows are operated for our service
-        // i.e. Update user's column with userService.updateUser
-        return userService.updateUser(user_params)
-          .then(onSuccess);
-
-        function onSuccess (response) {
-          var user = response.data.user;
-
-          OneSignal.push(["sendTag", "user_id", user.id]);
-          OneSignal.push(["sendTag", "user_name", user.name]);
-          OneSignal.push(["sendTag", "user_email", user.email]);
-        }
-      });
-    }
-  });
-})
+});


### PR DESCRIPTION
おそらく `assets:precompile` にて `ENV['ONESIGNAL_APP_ID']` が解決されず（ `dotenv` 経由で読み出すことを前提としているため）コンパイルされたjsに `appId` が代入されなかった。

とりあえずの策として平文を使いました。（リポジトリを見れば `APP_ID, REST_API_KEY` どちらもバレるがブラウザから閲覧する分にはほぼバレないため大丈夫かなという浅はかな判断）